### PR TITLE
transfer: ignore secret error only if not found

### DIFF
--- a/cirruslib/transfer.py
+++ b/cirruslib/transfer.py
@@ -46,9 +46,12 @@ def get_s3_session(bucket: str=None, s3url: str=None, **kwargs) -> s3:
         secret_name = f"cirrus-creds-{bucket}"
         _creds = secrets.get_secret(secret_name)
         creds.update(_creds)
-    except ClientError:
-        # using default credentials
-        pass
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            logger.info(f"Secret not found, using default credentials: '{secret_name}'")
+            pass
+        # some other client error we cannot handle
+        raise e
 
 
     requester_pays = creds.pop('requester_pays', False)


### PR DESCRIPTION
`ClientError` for a secret lookup encapsulates five different exception types:

* `DecryptionFailureException`
* `InternalServiceErrorException`
* `InvalidParameterException`
* `InvalidRequestException`
* `ResourceNotFoundException`

It seems of these exceptions the only one that makes sense in this context to ignore is the `ResourceNotFoundException`, whereas the others cannot be adequately handled here.

Note I attempted to add tests for these changes, but it appears the transfer test may not be mocked out properly (they appear to be making actual API requests to AWS) and they were not working for me as-is. As a result I punted on adding tests around the new handling here, but I can work on that if needed.