### PR TITLE
Fix exception traceback logging

### DIFF
--- a/cirruslib/logging.py
+++ b/cirruslib/logging.py
@@ -57,14 +57,16 @@ class DynamicLoggerAdapter(logging.LoggerAdapter):
 
     def process(self, msg, kwargs):
         if self.keys is not None:
-            kwargs = {k: self.extra[k] for k in self.keys if k in self.extra}
-            return (msg, {"extra": kwargs})
-        else:
-            return (msg, kwargs)
+            kwargs['extra'] = {
+                k: self.extra[k]
+                for k in self.keys
+                if k in self.extra
+            }
+        return (msg, kwargs)
 
 
 def get_task_logger(*args, catalog, **kwargs):
     _logger = logging.getLogger(*args, **kwargs)
     logger = DynamicLoggerAdapter(_logger, catalog, keys=['id', 'stac_version'])
     return logger
-    
+


### PR DESCRIPTION
This change set ensures logging kwargs are still used even when the logging adapter has keys set, which is necessary to ensure `exc_info` is passed along when logging an exception using `logger.exception()`.