### PR TITLE
python 3.9 and 3.10 support

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 mock==4.0.2
-pytest~=5.4
+pytest~=6.2
 pytest-cov~=2.9
 moto~=1.3.16
 flake8~=3.8

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,9 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     keywords='',
     packages=find_namespace_packages('src'),


### PR DESCRIPTION
Update tests to run with python 3.9 and 3.10; update classifiers in setup.py.