### PR TITLE
fix issues with duplicate payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+
+## [v0.6.2] - 2022-02-07
+
+### Fixed
+
+* Issues when payloads are duplicated ([#41])
+
 ## [v0.6.1] - 2022-01-13
 
 ### Added
@@ -204,7 +211,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial Release
 
-[Unreleased]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.6.1...main
+[Unreleased]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.6.2...main
+[v0.6.2]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.6.1...v0.6.2
 [v0.6.1]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.6.0...v0.6.1
 [v0.6.0]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.5.1...v0.6.0
 [v0.5.1]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.5.0...v0.5.1
@@ -234,6 +242,7 @@ Initial Release
 [#34]: https://github.com/cirrus-geo/cirrus-lib/pull/34
 [#37]: https://github.com/cirrus-geo/cirrus-lib/pull/37
 [#38]: https://github.com/cirrus-geo/cirrus-lib/pull/38
+[#41]: https://github.com/cirrus-geo/cirrus-lib/pull/41
 
 [c919fad]: https://github.com/cirrus-geo/cirrus-lib/commit/c919fadb83bb4f5cdfd082d482e25975ce12aa2c
 [02ff5e3]: https://github.com/cirrus-geo/cirrus-lib/commit/02ff5e33412026b1fedda97727eef66715a27492

--- a/src/cirrus/lib/process_payload.py
+++ b/src/cirrus/lib/process_payload.py
@@ -494,12 +494,14 @@ class ProcessPayloads(object):
             #if state in ['QUEUED', 'PROCESSING']:
             #    logger.info(f"Skipping {payload['id']}, in {state} state")
             #    continue
-            if state in ['FAILED', ''] or _replace:
+            if payload['id'] in payload_ids:
+                logger.warning(f"Dropping duplicated payload {payload['id']}")
+            elif state in ['FAILED', ''] or _replace:
                 payload_id = payload()
                 if payload_id is not None:
                     payload_ids.append(payload_id)
             else:
-                logger.info(f"Skipping, input already in {state} state")
+                logger.info(f"Skipping {payload['id']}, input already in {state} state")
                 continue
 
         return payload_ids

--- a/src/cirrus/lib/statedb.py
+++ b/src/cirrus/lib/statedb.py
@@ -77,7 +77,7 @@ class StateDB:
         try:
             resp = self.db.meta.client.batch_get_item(RequestItems={
                 self.table_name: {
-                    'Keys': [self.payload_id_to_key(id) for id in payload_ids]
+                    'Keys': [self.payload_id_to_key(id) for id in set(payload_ids)]
                 }
             })
             items = []

--- a/tests/test_statedb.py
+++ b/tests/test_statedb.py
@@ -139,6 +139,13 @@ class TestDbItems(unittest.TestCase):
         for dbitem in dbitems:
             assert(self.statedb.key_to_payload_id(dbitem) in ids)
 
+    def test_get_dbitems_duplicates(self):
+        ids = [test_item['id'] + str(i) for i in range(10)]
+        ids.append(ids[0])
+        dbitems = self.statedb.get_dbitems(ids)
+        for dbitem in dbitems:
+            assert(self.statedb.key_to_payload_id(dbitem) in ids)
+
     def test_get_dbitems_noitems(self):
         #with self.assertRaises(Exception):
         dbitems = self.statedb.get_dbitems([test_item['id']])


### PR DESCRIPTION
See cirrus-geo/cirrus-geo#84 for additional context.

* Deduplicate payload IDs when querying dynamo for payload states.
* Drop duplicated payloads when processing multiple payloads: the first is preserved, to be consistent with the behavior if a second payload instance is received while the first is still processing.