### PR TITLE
Add `ABORTED` state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 
+## [v0.7.0] - 2022-02-17
+
+### Added
+
+* Support for an `ABORTED` workflow state ([#44])
+
+
 ## [v0.6.2] - 2022-02-07
 
 ### Fixed
@@ -211,7 +218,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial Release
 
-[Unreleased]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.6.2...main
+[Unreleased]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.7.0...main
+[v0.7.0]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.6.2...v0.7.0
 [v0.6.2]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.6.1...v0.6.2
 [v0.6.1]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.6.0...v0.6.1
 [v0.6.0]: https://github.com/cirrus-geo/cirrus-lib/compare/v0.5.1...v0.6.0
@@ -244,6 +252,7 @@ Initial Release
 [#38]: https://github.com/cirrus-geo/cirrus-lib/pull/38
 [#41]: https://github.com/cirrus-geo/cirrus-lib/pull/41
 
+[#44]: https://github.com/cirrus-geo/cirrus-lib/issues/41
+
 [c919fad]: https://github.com/cirrus-geo/cirrus-lib/commit/c919fadb83bb4f5cdfd082d482e25975ce12aa2c
 [02ff5e3]: https://github.com/cirrus-geo/cirrus-lib/commit/02ff5e33412026b1fedda97727eef66715a27492
-

--- a/src/cirrus/lib/process_payload.py
+++ b/src/cirrus/lib/process_payload.py
@@ -456,7 +456,7 @@ class ProcessPayloads(object):
 
         Args:
             collections (str): String of collections (input or output depending on `index`)
-            state (str): The state (QUEUED, PROCESSING, COMPLETED, FAILED, INVALID) of StateDB Items to get
+            state (str): The state (QUEUED, PROCESSING, COMPLETED, FAILED, INVALID, ABORTED) of StateDB Items to get
             since (str, optional): Get Items since this duration ago (e.g., 10m, 8h, 1w). Defaults to None.
             index (str, optional): 'input_state' or 'output_state' Defaults to 'input_state'.
             limit ([type], optional): Max number of Items to return. Defaults to None.
@@ -496,7 +496,7 @@ class ProcessPayloads(object):
             #    continue
             if payload['id'] in payload_ids:
                 logger.warning(f"Dropping duplicated payload {payload['id']}")
-            elif state in ['FAILED', ''] or _replace:
+            elif state in ['FAILED', 'ABORTED', ''] or _replace:
                 payload_id = payload()
                 if payload_id is not None:
                     payload_ids.append(payload_id)

--- a/tests/test_process_payload.py
+++ b/tests/test_process_payload.py
@@ -22,6 +22,11 @@ def base_payload():
 
 
 @pytest.fixture()
+def capella_payload():
+    return read_json_fixture('capella-fixture-2.json')
+
+
+@pytest.fixture()
 def sqs_event():
     return read_json_fixture('sqs-event.json')
 


### PR DESCRIPTION
Works like `FAILED` in that it allows rerunning jobs, but doesn't have an associated last error message. Closes #44.