### PR TITLE
initial workflow callback support

### DIFF
--- a/src/cirrus/lib/callbackdb.py
+++ b/src/cirrus/lib/callbackdb.py
@@ -1,0 +1,242 @@
+import boto3
+import logging
+import os
+import datetime
+
+from typing import List, Literal
+from boto3.dynamodb.conditions import Key, Attr
+
+from cirrus.lib.statedb import STATES, IN_PROGRESS_STATES, FINAL_STATES
+
+
+logger = logging.getLogger(__name__)
+
+DYNAMO = boto3.resource('dynamodb')
+
+STATES_LITERAL = Literal[tuple(STATES)]
+FINAL_STATES_LITERAL = Literal[tuple(FINAL_STATES)]
+
+TTL_ON_FINAL_STATE = datetime.timedelta(days=60)
+
+
+def find_expiration_time() -> int:
+    return int((datetime.datetime.now() + TTL_ON_FINAL_STATE).timestamp())
+
+
+class CallbackDB:
+    def __init__(self, table_name: str=os.getenv('CIRRUS_CALLBACK_DB', 'test')):
+        """Initialize a CallbackDB instance using the Cirrus Callback DB table
+
+        Args:
+            table_name (str, optional): The Cirrus Callbakc DB Table name. Defaults to os.getenv('CIRRUS_CALLBACK_DB', None).
+        """
+        # initialize client
+        self.db = DYNAMO
+        self.table_name = table_name
+        self.table = self.db.Table(table_name)
+
+    def delete(self):
+        # delete table (used for testing)
+        self.table.delete()
+        self.table.wait_until_not_exists()
+
+    @staticmethod
+    def payload_to_key(payload) -> str:
+        """Construct the callback DB key from a ProcessPayload instance
+
+        Args:
+            payload (ProcessPayload): ProcessPayload instance
+
+        Raises:
+
+        Returns:
+            str: callback DB key string
+        """
+        return '{}_{}_{}'.format(
+            payload.process['workflow'],
+            payload.collections_hash(),
+            payload.items_hash(),
+        )
+
+    def create_callback(
+        self,
+        callback_token: str,
+        payload_key: str,
+        items: List[str],
+        workflow_state: STATES_LITERAL,
+    ) -> None:
+        """Create a workflow callback record for a ProcessPayload
+
+        Args:
+            callback_token (str): the workflow callback token
+            payload_key (str): the payload key for the ProcessPayload
+            items (List[str]): the list of "collection/itemid" strings
+                               representing the payload items
+            workflow_state (str): current workflow state
+
+        Returns:
+            None
+        """
+        logger.debug("Creating callback for token '%s', payload '%s'", callback_token, payload_key)
+        item = {
+            'callback_token': callback_token,
+            'collections_items': items,
+            'workflow_collections256_itemids256': payload_key,
+            'workflow_state': workflow_state,
+        }
+
+        if workflow_state in FINAL_STATES:
+            item['expiration_time'] = find_expiration_time()
+
+        response = self.table.put_item(
+            Item=item,
+            # prevents overwriting an existing entry
+            ConditionExpression='attribute_not_exists(expiration_time)',
+        )
+        logger.debug("Created callback: %s", item)
+        return response
+
+    def create_callbacks(
+        self,
+        callback_tokens: str,
+        payload_key: str,
+        items: List[str],
+        workflow_state: STATES_LITERAL,
+    ) -> None:
+        """Creates workflow callback records for a ProcessPayload from a list of tokens
+
+        Args:
+            callback_tokens (List[str]): the workflow callback tokens
+            payload_key (str): the payload key for the ProcessPayload
+            items (List[str]): the list of "collection/itemid" strings
+                               representing the payload items
+            workflow_state (str): current workflow state
+
+        Returns:
+            None
+        """
+        for token in callback_tokens:
+            try:
+                self.create_callback(token, payload_key, items, workflow_state)
+            except Exception:
+                logger.exception(
+                    'Failed to create callback record: %s, %s, %s, %s',
+                    token,
+                    payload_key,
+                    items,
+                    workflow_state,
+                )
+
+    def get_payload_callback_tokens(self, payload_key: str, exclude_final_states: bool=True) -> List[str]:
+        """Get all workflow callback tokens for a ProcessPayload
+
+        Args:
+            payload_key (str): the payload key for the ProcessPayload
+
+        Keyword Args:
+            exclude_final_states (bool): if True (default), return only
+                                         tokens for records in non-final
+                                         states
+
+        Returns:
+            List[str]: callback tokens
+        """
+        # if results are paginated,
+        # we'll only query up to this
+        # max number of pages
+        MAX_PAGES = 100
+        tokens = []
+
+        key_cond = Key('workflow_collections256_itemids256').eq(payload_key)
+        query = {
+            'IndexName': 'by_payload',
+            'KeyConditionExpression': key_cond,
+        }
+
+        if exclude_final_states:
+            query['FilterExpression'] = Attr('workflow_state').is_in(IN_PROGRESS_STATES)
+
+        page = 0
+        while True:
+            response = self.table.query(**query)
+
+            tokens += [item['callback_token']['S'] for item in response['Items']]
+
+            if not 'LastEvaluatedKey' in response:
+                break
+            if page >= MAX_PAGES:
+                logger.error(
+                    "More than %s pages of callbacks for payload '%s': cowardly refusing to continue dynamo queries",
+                    MAX_PAGES,
+                    payload_key,
+                )
+                break
+
+            # we have more pages of results
+            query['ExclusiveStartKey'] = response['LastEvaluatedKey']
+            page += 1
+
+        return tokens
+
+    def set_final_state(self, callback_token: str, final_state: FINAL_STATES_LITERAL):
+        """Update the workflow state of callback record with a final processing state
+
+        Args:
+            callback_token (str): the workflow callback token
+            final_state (str): final workflow state
+
+        Raises:
+            ValueError on invalid final state
+
+        Returns:
+            dynamodb response object
+        """
+        if final_state not in FINAL_STATES:
+            raise ValueError(f'Not a valid final workflow state: {final_state}')
+
+        response = self.table.update_item(
+            Key={'callback_token': callback_token},
+            UpdateExpression=(
+                'SET '
+                'expiration_time = :expiration, '
+                'workflow_state = :state'
+            ),
+            # prevents updates to an existing entry
+            ConditionExpression='attribute_not_exists(expiration_time)',
+            ExpressionAttributeValues={
+                ':expiration': find_expiration_time(),
+                ':state': final_state,
+            }
+        )
+        logger.debug("Update callback token '%s' to state '%s'", callback_token, final_state)
+        return response
+
+    def set_final_state_multiple(
+        self,
+        callback_tokens: List[str],
+        final_state: FINAL_STATES_LITERAL,
+    ) -> None:
+        """Update multiple callback records with a final processing state
+
+        Args:
+            callback_tokens (List[str]): the workflow callback tokens
+            final_state (str): final workflow state
+
+        Raises:
+            ValueError on invalid final state
+
+        Returns:
+            None
+        """
+        if final_state not in FINAL_STATES:
+            raise ValueError(f'Not a valid final workflow state: {final_state}')
+
+        for token in callback_tokens:
+            try:
+                self.set_final_state(token, final_state)
+            except Exception:
+                logger.exception(
+                    'Failed to set state on callback record: %s, %s',
+                    token,
+                    final_state,
+                )

--- a/src/cirrus/lib/statedb.py
+++ b/src/cirrus/lib/statedb.py
@@ -1,9 +1,7 @@
 import boto3
-import json
 import logging
 import os
 
-from boto3utils import s3
 from boto3.dynamodb.conditions import Key
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional, List
@@ -11,7 +9,11 @@ from typing import Dict, Optional, List
 # envvars
 PAYLOAD_BUCKET = os.getenv('CIRRUS_PAYLOAD_BUCKET')
 
-STATES = ['PROCESSING', 'COMPLETED', 'FAILED', 'INVALID', 'ABORTED']
+SUCCESS_STATES = ['COMPLETED']
+FAILED_STATES = ['FAILED', 'INVALID', 'ABORTED']
+IN_PROGRESS_STATES = ['PROCESSING']
+FINAL_STATES = SUCCESS_STATES + FAILED_STATES
+STATES = IN_PROGRESS_STATES + FINAL_STATES
 
 # logging
 logger = logging.getLogger(__name__)
@@ -85,8 +87,8 @@ class StateDB:
                 items.append(r)
             logger.debug(f"Fetched {len(items)} items")
             return items
-        except Exception as err:
-            msg = f"Error fetching items"
+        except Exception:
+            msg = "Error fetching items"
             logger.error(msg, exc_info=True)
             raise Exception(msg)
 


### PR DESCRIPTION
## What is this?

The issue of how to handle processing items dependent on n other items seems to be a reoccurring theme lately when discussing how best to structure cirrus workflows modeling such dependencies. Some purpose-built solutions have been suggested for particular instances of this issue, but a larger question has been asked: can we find a solution worthy of integration into cirrus to support this use-case more generally?

## An idea: workflow callbacks

In thinking through this problem, I stumbled upon support within step functions for task tokens, [which can be used to pause a step function execution until a token is returned](https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-wait-token). It works like this:

* Step function sends a message to SQS with a task token
* A lambda or some other resource handles the messages in that queue
* When the response is ready then something calls `SendTaskSuccess` or `SendtaskFailure`, as appropriate, with the specified token
* If success, the step function resumes at the next step. If failed, then the step function fails the current step.

Within cirrus, we could use this mechanism to wait on items to be published from other workflows. For example, the SQS could be the cirrus process SQS and the message could be the cirrus process payload for the child workflow. That payload would include a task token in it corresponding to the waiting step function task.

If we could guarantee a one-to-one relation between workflows in this process, we could simply have `update-state` call the `SendTaskSuccess` or `SendTaskFailed` using the task token from the input payload, if one is present. However, we have no such guarantees: multiple workflow might be dependent on the same items, so we have to add some complexity to handle these possible many-to-one relations.

I propose we use a dynamodb table to track these relations. The schema would looks something like:

* `payload_id`: the ID from a workflow payload (partition key)
* `task_token`: the token of the waiting step function task (sort key)
* `workflow_state`: the final state of the workflow corresponding to payload_id
* `expiration_time`: a field that can be used to track if the callback has been executed and can be used with a table ttl to expire records (so we don’t infinitely grow the table but can keep records around for a limited time as part of an audit trail)

We could use a table stream to have a lambda process all records when `workflow_state` is set and make the callback to `SendTaskSuccess` or `SendTaskFailed`, setting `expiration_time` when that happens. Then `update-state` would only have to query for all records in this table with the `payload_id` and update them with the workflow’s final state.

`process` would persist a task token in an input payload to that dynamo table regardless of the whether it kicks off a workflow. We could map the `workflow_state` values to the same as those for payload items, where `PROCESSING` means another update is coming, `COMPLETED` means to send a success notification, and `INVALID` triggers a failure notification (the other states encountered in process would trigger a workflow run and would therefore default to `PROCESSING`).

Here is a diagram of this flow, not sure if it makes sense or not though:

```
     workflow 1
       start
         |
         |
        find
    dependencies
         |
         |
     Parallel
     +---+---+
     |   |   |
     |   |   |
   create payload
     |   |   |
     |   |   |
    send payload
  to cirrus process  ---+-->  process (payload 123, callback a)  --->  workflow 2  ---> update-state
  (await callback)      |       |                                                                |
     |   |   |          +-->  process (payload 234, callback b) (already completed)              |
     |   |   |          |       | |                                                              |
     +-+-+-+-+          +-->  process (payload 345, callback c) (already in progress)            |
         |                      | | |                                                            |
         |                      | | |                                                            |
    do something                | | |     Dependency tracking table                              |
         |                      | | |     (payload id, callback token, workflow state, expiration time)
         |                      | | |                                                            |
        end                     | | +-->  345, c, PROCESSING, null  -------->  wait for update-state from that workflow
                                | |                                                              |
                                | +---->  234, b, COMPLETED, now + 2mo  ---->  lambda to send success to b
                                |                                                                |
                                +------>  123, a, PROCESSING, null  <---update to COMPLETED------+
                                                                          |
                                                                          +->  lambda to send success to a
```

### Handling multiple dependencies within a workflow

It should be possible to use dynamic parallelism to create as many parallel tasks as required to queue up all other workflows, waiting until they all complete to resume the dependent root workflow.

### Preventing hanging workflows

It would be possible to combine the waiting tasks with a timeout, so if the dependencies are not completed in a reasonable time the root workflow will fail, triggering awareness of the issue.

It would also be possible to have tooling/alarms looking for long-running step function executions.

## Potential Negatives

### Race conditions

Depending how we implement this, we could have end up with a risk of race conditions. I think by using the table stream and always having `process` add a row to the table we could mitigate that potential entirely, but I might be overlooking some edge cases.

### Complexity

This seems like it might be a complex solution, but we need some external state tracking to make this work, so I’m not sure any alternatives would be any less complex.

### AWS-centric

It could be hard to implement a mechanism like this on alternative platforms.

### Capacity limitations

An advantage of this solution is that it does not require any daemon-like process to poll for state updates or handle events, outside the step function platform itself. Therefore we do not incur any costs for a workflow waiting on dependencies, aside from the fact that it uses up one of the 1,000,000 step function limit (and it appears this limit can be increased upon request).

In high-volume workflow situations, it could therefore be possible to cause a deadlock where too many workflows are waiting on items to be processed to be able to start workflows to process those items. I don’t see a good solution to this issue beyond preventing it in the first place.

As a best-practice, then, I would suggest not relying solely on this workflow dependency relationship to trigger processing for dependencies in high-volume situations. Generally it is better to have a process to ensure all lower layers items are as present as possible using an alternative feeder method, and rely on this dependency relationship only for a minimal number of items on “the edge” of the other feeder’s processing.